### PR TITLE
FIX - PolylineUtils.footingPointOnPolyline2d

### DIFF
--- a/__tests__/collisionTests.test.ts
+++ b/__tests__/collisionTests.test.ts
@@ -44,7 +44,7 @@ describe('Collision Tests', () => {
         expect(collisionCheck.result).toBe(true);
     });
 
-    test('Collision Test Line and Triangle', () => {
+    test('Collision Test Line and Triangle Edge', () => {
         const line: Line = {
             p0: {x: 0, y: 5, z: 0},
             p1: {x: 15, y: 5, z: 0},
@@ -57,6 +57,22 @@ describe('Collision Tests', () => {
         }
 
         const collisions = CollisionUtils.getCollisionLineWithTriangleEdges(line, triangle);
+        console.log(collisions);
+    });
+
+    test('Collision Test Line and Triangle Surface', () => {
+        const line: Line = {
+            p0: {x: 0, y: 5, z: 10},
+            p1: {x: 15, y: 5, z: 0},
+        }
+
+        const triangle: Triangle = {
+            p0: {x: 0, y: 0, z: 0},
+            p1: {x: 10, y: 0, z: 10},
+            p2: {x: 10, y: 10, z: 10},
+        }
+
+        const collisions = CollisionUtils.getCollisionLineWithTriangleSurface(line, triangle);
         console.log(collisions);
     });
 });

--- a/__tests__/collisionTests.test.ts
+++ b/__tests__/collisionTests.test.ts
@@ -1,4 +1,4 @@
-import { BoundingBox2d, BoundingBox3d } from "../src/models/types/basicGeometries";
+import { BoundingBox2d, BoundingBox3d, Line, Triangle } from "../src/models/types/basicGeometries";
 import { CollisionUtils } from "../src/utils/collisionUtils";
 
 describe('Collision Tests', () => {
@@ -22,7 +22,7 @@ describe('Collision Tests', () => {
         expect(collisionCheck.result).toBe(true);
     });
 
-    test('Collision Test 3d, when mees at a side', () => {
+    test('Collision Test 3d, when meets at a side', () => {
         const boxA: BoundingBox3d = {
             anchor: { x: 0, y: 0, z: 0 },
             uAxis: { x: 1, y: 0, z: 0 },
@@ -42,5 +42,21 @@ describe('Collision Tests', () => {
         console.log(collisionCheck.args);
 
         expect(collisionCheck.result).toBe(true);
+    });
+
+    test('Collision Test Line and Triangle', () => {
+        const line: Line = {
+            p0: {x: 0, y: 5, z: 0},
+            p1: {x: 15, y: 5, z: 0},
+        }
+
+        const triangle: Triangle = {
+            p0: {x: 0, y: 0, z: 0},
+            p1: {x: 10, y: 0, z: 0},
+            p2: {x: 10, y: 10, z: 0},
+        }
+
+        const collisions = CollisionUtils.getCollisionLineWithTriangleEdges(line, triangle);
+        console.log(collisions);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "jakke-graphics-ts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "node pack.config.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [],
   "author": "JakkeLab",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "author": "JakkeLab",
   "license": "MIT",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url" : "https://github.com/JakkeLab-AEC/jakke-graphics-ts"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/src/utils/collisionUtils.ts
+++ b/src/utils/collisionUtils.ts
@@ -225,8 +225,48 @@ function getCollisionLineWithTriangleEdges(line: Line, triangle: Triangle) {
     return sortedPts;
 }
 
+function getCollisionLineWithTriangleSurface(line: Line, triangle: Triangle): Vertex3d | undefined {
+    if(isDetZero(line, triangle)) return;
+
+    const v0 = triangle.p0;
+    const v1 = triangle.p1;
+    const v2 = triangle.p2;
+
+    const p0 = line.p0;
+    const p1 = line.p1;
+
+    const v0v1 = VectorUtils.subtract(v1, v0);
+    const v0v2 = VectorUtils.subtract(v2, v0);
+    const v0p0 = VectorUtils.subtract(p0, v0);
+    const d = VectorUtils.chain(p1).subtract(p0).normalize().value();
+
+    const det = VectorUtils.dot(v0v1, VectorUtils.cross(d, v0v2));
+
+    const v = VectorUtils.dot(d, VectorUtils.cross(v0v2, v0p0)) / det
+    const w = VectorUtils.dot(d, VectorUtils.cross(v0p0, v0v1)) / det
+    const u = 1 - (v + w);
+
+    const result = VectorUtils.chain(v0)
+        .scale(u)
+        .add(VectorUtils.scale(v1, v))
+        .add(VectorUtils.scale(v2, w))
+        .value();
+
+    const validParams = [u, v, w].every(val => val >= 0 && val <= 1);
+    return validParams ? result : undefined;
+}
+
+function isDetZero(line: Line, triangle: Triangle) {
+    const v0v1 = VectorUtils.subtract(triangle.p1, triangle.p0);
+    const v0v2 = VectorUtils.subtract(triangle.p2, triangle.p0);
+    const d = VectorUtils.subtract(line.p1, line.p0);
+    const det = VectorUtils.dot(v0v1, VectorUtils.cross(d, v0v2));
+    return det === 0;
+}
+
 export const CollisionUtils = {
     hasBoundingBoxCollision2d,
     hasBoundingBoxCollision3d,
-    getCollisionLineWithTriangleEdges
+    getCollisionLineWithTriangleEdges,
+    getCollisionLineWithTriangleSurface
 }

--- a/src/utils/collisionUtils.ts
+++ b/src/utils/collisionUtils.ts
@@ -1,4 +1,4 @@
-import { BoundingBox2d, BoundingBox3d, Vertex2d, Vertex3d } from "../models/types/basicGeometries"
+import { BoundingBox2d, BoundingBox3d, Line, Triangle, Vertex2d, Vertex3d } from "../models/types/basicGeometries"
 import { VectorUtils } from "./vectorUtils"
 import { LineEvaluation } from "./lineEvaluationUtils"
 import { ActionResult } from "../models/types/errorMessages"
@@ -204,7 +204,29 @@ function hasBoundingBoxCollision3d(boxA: BoundingBox3d, boxB: BoundingBox3d, inc
     }
 }
 
+function getCollisionLineWithTriangleEdges(line: Line, triangle: Triangle) {
+    const AB: Line = {p0: triangle.p0, p1: triangle.p1};
+    const BC: Line = {p0: triangle.p1, p1: triangle.p2};
+    const CA: Line = {p0: triangle.p2, p1: triangle.p0};
+
+    const intersectionOnAB = LineEvaluation.getIntersection(line, AB);
+    const intersectionOnBC = LineEvaluation.getIntersection(line, BC);
+    const intersectionOnCA = LineEvaluation.getIntersection(line, CA);
+
+    const pts: Vertex3d[] = [];
+    if(intersectionOnAB.result && intersectionOnAB.pt) pts.push(intersectionOnAB.pt);
+    if(intersectionOnBC.result && intersectionOnBC.pt) pts.push(intersectionOnBC.pt);
+    if(intersectionOnCA.result && intersectionOnCA.pt) pts.push(intersectionOnCA.pt);
+
+    const sortedPts = pts.map(p => {
+        return {t: LineEvaluation.getParameterOnLine(line.p0, line.p1, p), p}
+    }).sort((a, b) => a.t - b.t);
+
+    return sortedPts;
+}
+
 export const CollisionUtils = {
     hasBoundingBoxCollision2d,
-    hasBoundingBoxCollision3d
+    hasBoundingBoxCollision3d,
+    getCollisionLineWithTriangleEdges
 }

--- a/src/utils/polylineUtils.ts
+++ b/src/utils/polylineUtils.ts
@@ -9,7 +9,7 @@ type EvaluationFactorInternal = {travelDistanceOnPolyline: number, distToFooting
 
 function footingPointOnPolyline2d(polyline: Polyline2d, pt: Vertex2d, includeEnds = false): {pt: Vertex2d, t: number}|undefined {
     // Filter when polyline is actually a point or line.
-    if(polyline.length < 3) return;
+    if(polyline.length < 2) return;
     
     // Filter when polyline is actually no length.
     const poylineLength = getLengthPolyline2d(polyline);
@@ -23,7 +23,8 @@ function footingPointOnPolyline2d(polyline: Polyline2d, pt: Vertex2d, includeEnd
         const p0 = VectorUtils.to3d(polyline[i]);
         const p1 = VectorUtils.to3d(polyline[i+1]);
         if(i > 0) {
-            lengthSum += VectorUtils.getDist(p0, p1);
+            const pFormer = VectorUtils.to3d(polyline[i-1]);
+            lengthSum += VectorUtils.getDist(pFormer, p0);
         }
         
         const lineSegment: Line = {p0: p0, p1: p1};
@@ -53,7 +54,7 @@ function footingPointOnPolyline2d(polyline: Polyline2d, pt: Vertex2d, includeEnd
 
 function footingPointOnPolyline3d(polyline: Polyline3d, pt: Vertex3d, includeEnds = false): {pt: Vertex3d, t: number}|undefined {
     // Filter when polyline is actually a point or line.
-    if(polyline.length < 3) return;
+    if(polyline.length < 2) return;
     
     // Filter when polyline is actually no length.
     const poylineLength = getLengthPolyline3d(polyline);

--- a/src/utils/polylineUtils.ts
+++ b/src/utils/polylineUtils.ts
@@ -132,5 +132,5 @@ export const PolylineUtils = {
     footingPointOnPolyline3d,
     getLengthPolyline2d,
     getLengthPolyline3d,
-    getIntersectionWithLine
+    getIntersectionWithLine,
 }


### PR DESCRIPTION
### Fixed
- Corrected an off-by-one error in polyline segment length accumulation.
- This bug affected the calculation of a point's relative position `t` (0 ≤ t ≤ 1) along a polyline.
- For example, when trying to interpolate a point halfway along a 3-segment polyline, the calculation could return a position slightly before or after the expected point.
- The issue was caused by incorrect handling of the cumulative segment lengths — either one segment was skipped or the total length array was misaligned.
- This has been resolved, and now the relative position is accurately computed for any point along the polyline.

```ts
...
// Loop the polyline
    const factors: EvaluationFactorInternal[] = [];
    const ptFrom = VectorUtils.to3d(pt);
    let lengthSum = 0;
    for(let i = 0; i < polyline.length - 1; i++) {
        const p0 = VectorUtils.to3d(polyline[i]);
        const p1 = VectorUtils.to3d(polyline[i+1]);
        if(i > 0) {
            const pFormer = VectorUtils.to3d(polyline[i-1]);
            lengthSum += VectorUtils.getDist(pFormer, p0);
        }
...
```